### PR TITLE
Change order of settings

### DIFF
--- a/core/src/main/scala/backbone/consumer/Consumer.scala
+++ b/core/src/main/scala/backbone/consumer/Consumer.scala
@@ -69,8 +69,8 @@ class Consumer(settings: Settings)(implicit system: ActorSystem, val sqs: SqsAsy
 
     val baseSqsSourceSettings = SqsSourceSettings.Defaults
       .withWaitTimeSeconds(settings.receiveSettings.waitTimeSeconds)
-      .withMaxBufferSize(settings.receiveSettings.maxBufferSize)
       .withMaxBatchSize(settings.receiveSettings.maxBatchSize)
+      .withMaxBufferSize(settings.receiveSettings.maxBufferSize)
       .withParallelRequests(settings.receiveSettings.parallelRequests)
       .withAttributes(settings.receiveSettings.attributeNames)
       .withMessageAttributes(settings.receiveSettings.messageAttributeNames)


### PR DESCRIPTION
change order of settings init for maxBatchSize and maxBufferSize as t…hey have a check and it clashes if the maxBatchSize is greater than the maxBufferSize