### PR TITLE
Downgrade play-json.

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,3 +1,7 @@
 updates.ignore = [
   {groupId = "com.typesafe.akka", artifactId = "akka-testkit"} // Must be the same version as pulled in by alpakka
 ]
+
+updates.pin  = [
+  { groupId = "com.typesafe.play", artifactId="play-json", version = "2." }
+]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
   ) ++ testDependencies
 
   val jsonPlay: Seq[ModuleID] = Seq(
-    "org.playframework" %% "play-json" % "3.0.2"
+    "com.typesafe.play" %% "play-json" % "2.10.4"
   ) ++ testDependencies
 
   val jsonGson: Seq[ModuleID] = Seq(


### PR DESCRIPTION
Was updated to 3.x, but that is for Play 3 and we are still on 2.9. Also pinned version 2.x in .scala-steward.conf.