### PR TITLE
Add 'setup-sbt' action to Github workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'sbt'
 
+      - uses: sbt/setup-sbt@v1
+
       - name: Build project
         run: sbt codeVerify coverage +test coverageReport coverageAggregate
 


### PR DESCRIPTION
Due to the latest upgrade of the Ubuntu version used in actions, 'setup-java' no longer includes sbt.
Use this official sbt action to add it.